### PR TITLE
index: Update rich snippet to use GitHub url

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@ permalink: /
     <meta name="HandheldFriendly" content="true" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta property="og:title" content="Congo Developers Club">
-    <meta property="og:url" content="https://congo-developers-club.onrender.com/">
-    <meta property="og:image" content="{{ site.baseurl }}/images/cdc.png">
+    <meta property="og:url" content="https://congoclub.github.io/cdc_site/">
+    <meta property="og:image" content="https://congoclub.github.io/cdc_site/images/cdc.png">
     <meta property="og:description" content="The Congo Developers Club is an online place where developers across Congo and Central Africa can exchange ideas, experiences and opportunities in the field of computer science and personal / professional development.">
 
     <!-- favicons -->


### PR DESCRIPTION
This updates the `og:metadata` in `index.html` to use the GitHub pages url instead of the preview site URL from earlier today.