### PR TITLE
index: Center text below social media icons on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@ permalink: /
 
 {% if site.extra_html %}
 <div class="row justify-content-center">
-    <div class="col mt-3 text-sm-center fuse-core-extra">{{ site.extra_html }}</div>
+    <div class="col text-center mt-3 text-sm-center fuse-core-extra">{{ site.extra_html }}</div>
 </div>
 {% endif %}
 


### PR DESCRIPTION
This resolves on issue where the "Let's connect" text below the social
media buttons, wasn't aligned correctly in the middle of the page, when
viewed on mobile / handheld devices.

Before:

![image](https://user-images.githubusercontent.com/1130872/107155173-2f44e100-6977-11eb-8756-75a6b5cff6a8.png)

After:

![screenshot_07022021190259](https://user-images.githubusercontent.com/1130872/107155178-3cfa6680-6977-11eb-80e9-6fa98810200b.png)
