### PR TITLE
Use custom domain for GitHub pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Congo Developers Club Website
 
 This repository contains the source code for the [Congo
-Developers Club](https://congoclub.github.io/cdc_site/) website.
+Developers Club](https://congodevelopers.com/) website.
 
 Report problems or help improve the site by opening a [new
 issue](https://github.com/congoclub/cdc_site/issues/new/choose) or [pull

--- a/_config.yml
+++ b/_config.yml
@@ -25,13 +25,12 @@ robots:
     crawl: index,follow
 
 # website address when deployed, also given as canonical link
-url: https://congoclub.github.io/cdc_site/
+url: https://congodevelopers.com/
 
 # The 'baseurl' is prepended to all website-internal links.
 # 'baseurl' will often be '', but for a project page on gh-pages, it needs to be the project name.
 # If not empty, be careful to keep the leading slash, and don't add a slash at the end.
-#baseurl: ''
-baseurl: '/cdc_site'
+baseurl: ''
 
 # A picture of you, square(!), at least 180x180 pixels, more is better. Recommended file size < 100 KB.
 # Leave empty for generic placeholder image.

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@ permalink: /
     <meta name="HandheldFriendly" content="true" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta property="og:title" content="Congo Developers Club">
-    <meta property="og:url" content="https://congoclub.github.io/cdc_site/">
-    <meta property="og:image" content="https://congoclub.github.io/cdc_site/images/cdc.png">
+    <meta property="og:url" content="https://congodevelopers.com/">
+    <meta property="og:image" content="https://congodevelopers.com/images/cdc.png">
     <meta property="og:description" content="The Congo Developers Club is an online place where developers across Congo and Central Africa can exchange ideas, experiences and opportunities in the field of computer science and personal / professional development.">
 
     <!-- favicons -->


### PR DESCRIPTION
This PR utilizes the custom domain functionality for GitHub pages, so that Congo Developers Club site can be accessed directly via the easier to remember, newly registered domain name: https://congodevelopers.com/

Closes #4.

Cc: @davidkathoh 