### PR TITLE
config: Update expired Telegram invite link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ links:
   - telegram:
       name: Telegram
       show: true
-      href: https://t.me/joinchat/OR1D71XKGid7XmuHGD5I8A
+      href: https://t.me/joinchat/VcoaJw6PbJEky5lF
       icon: fab fa-telegram
   - github:
       name: GitHub


### PR DESCRIPTION
The previous link to self-invite to the Telegram group expired; asked
David for a new one and confirmed it's now working with this update.

Fixed.  👍